### PR TITLE
Docs: Add Parameters section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ call ddc#custom#patch_global('sourceOptions', {
 
 For fuzzy matching, change `matchers` to `matcher_fuzzy`.
 
+## Parameters
+
+- `commandsDir`
+    - Default: `~/.config/claude/commands`
+    - Directory path containing slash command files
+- `extensions`
+    - Default: `[".md"]`
+    - File extensions to include in completion
+
 See `:help ddc-source-slash-commands` for more options.
 
 ## License


### PR DESCRIPTION
## Summary

- Add missing Parameters section to README.md documenting `commandsDir` and `extensions` parameters
- This brings the README in line with the vim help documentation

## Test plan

- Documentation only change, no testing required
- Verified markdown formatting is correct