### PR TITLE
Feat: Add Claude Code plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ For fuzzy matching, change `matchers` to `matcher_fuzzy`.
 - `projectDirs`
     - Default: `[".claude/commands/", ".claude/skills/"]`
     - Project-level directories to scan (relative to current working directory)
+- `plugins`
+    - Default: `"off"`
+    - Plugin scanning mode: `"auto"`, `"on"`, or `"off"`
+    - `"auto"` and `"on"` enable plugin scanning (same behavior in current version)
+    - `"off"` disables plugin scanning (default for backward compatibility)
+- `userPluginPaths`
+    - Default: `[]`
+    - User-level plugin directories (absolute paths, tilde expanded)
+    - Each path must be a valid Claude Code plugin with `.claude-plugin/plugin.json`
+- `projectPluginPaths`
+    - Default: `[]`
+    - Project-level plugin directories (relative paths only)
+    - Absolute paths are rejected for security
+    - Paths must resolve within the project directory
 
 Example with custom directories
 
@@ -72,6 +86,17 @@ call ddc#custom#patch_global('sourceParams', {
   \ 'slash_commands': {
   \   'userDirs': ['~/.claude/commands/', '~/.claude/skills/'],
   \   'projectDirs': ['.claude/commands/', '.claude/skills/'],
+  \ }})
+```
+
+Example with plugin support enabled
+
+```vim
+call ddc#custom#patch_global('sourceParams', {
+  \ 'slash_commands': {
+  \   'plugins': 'on',
+  \   'userPluginPaths': ['~/my-plugins/code-review/'],
+  \   'projectPluginPaths': ['.plugins/deploy/'],
   \ }})
 ```
 
@@ -104,6 +129,13 @@ For default configuration:
 - `[commands:project]` - Project-level command
 - `[skills:user]` - User-level skill
 - `[skills:project]` - Project-level skill
+
+For plugin sources:
+
+- `[plugin:commands:user]` - User-level plugin command
+- `[plugin:commands:project]` - Project-level plugin command
+- `[plugin:skills:user]` - User-level plugin skill
+- `[plugin:skills:project]` - Project-level plugin skill
 
 NOTE: Menu labels use the directory name. Custom directories like `~/my-cmds/` will show `[my-cmds:user]`.
 

--- a/denops/@ddc-sources/slash_commands.ts
+++ b/denops/@ddc-sources/slash_commands.ts
@@ -3,13 +3,173 @@ import {
   type GatherArguments,
 } from "jsr:@shougo/ddc-vim@9.5.0/source";
 import type { Item } from "jsr:@shougo/ddc-vim@9.5.0/types";
-import { basename, dirname, join, resolve } from "jsr:@std/path@^1.0.8";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  resolve,
+} from "jsr:@std/path@^1.0.8";
 import { exists, expandGlob } from "jsr:@std/fs@^1.0.8";
 
 type Params = {
   userDirs: string[];
   projectDirs: string[];
+  plugins: "auto" | "on" | "off";
+  userPluginPaths: string[];
+  projectPluginPaths: string[];
 };
+
+/**
+ * Check if a path exists using Deno.stat.
+ */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a directory is a valid Claude Code plugin.
+ * A valid plugin must have .claude-plugin/plugin.json.
+ */
+async function isValidPlugin(pluginDir: string): Promise<boolean> {
+  const manifestPath = join(pluginDir, ".claude-plugin", "plugin.json");
+  return await pathExists(manifestPath);
+}
+
+/**
+ * Check if a resolved path is within the specified boundary.
+ * Uses Deno.realPath for symlink resolution.
+ * Note: Deno.realPath internally handles symlink loops.
+ */
+export async function isWithinBoundary(
+  path: string,
+  boundary: string,
+): Promise<boolean> {
+  try {
+    const realPath = await Deno.realPath(path);
+    const realBoundary = await Deno.realPath(boundary);
+    // Check if realPath starts with realBoundary
+    return realPath.startsWith(realBoundary + "/") ||
+      realPath === realBoundary;
+  } catch {
+    return false; // Path doesn't exist or permission denied
+  }
+}
+
+/**
+ * Scan a plugin directory for commands or skills.
+ *
+ * @param dir - Plugin subdirectory path (commands/ or skills/)
+ * @param pluginName - Name of the plugin (directory name)
+ * @param type - "commands" or "skills"
+ * @param scope - "user" or "project"
+ * @returns Array of completion items with [plugin:scope] menu
+ */
+export async function scanPluginDirectory(
+  dir: string,
+  pluginName: string,
+  type: "commands" | "skills",
+  scope: "user" | "project",
+): Promise<Item[]> {
+  if (!(await pathExists(dir))) {
+    return [];
+  }
+
+  const items: Item[] = [];
+
+  try {
+    if (type === "skills") {
+      // Skills: scan */SKILL.md pattern
+      const entries: string[] = [];
+      for await (const entry of expandGlob(join(dir, "*/SKILL.md"))) {
+        const skillName = basename(dirname(entry.path));
+        if (!skillName.startsWith(".")) {
+          entries.push(skillName);
+        }
+      }
+      // Lexical sort for deterministic results
+      entries.sort((a, b) => a.localeCompare(b));
+      for (const name of entries) {
+        items.push({
+          word: `/${pluginName}:${name}`,
+          menu: `[plugin:${scope}]`,
+        });
+      }
+    } else {
+      // Commands: scan *.md files
+      const entries: string[] = [];
+      for await (const entry of Deno.readDir(dir)) {
+        if (!entry.isFile) continue;
+        if (entry.name.startsWith(".")) continue;
+        if (!entry.name.endsWith(".md")) continue;
+        entries.push(basename(entry.name, ".md"));
+      }
+      // Lexical sort for deterministic results
+      entries.sort((a, b) => a.localeCompare(b));
+      for (const name of entries) {
+        items.push({
+          word: `/${pluginName}:${name}`,
+          menu: `[plugin:${scope}]`,
+        });
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  return items;
+}
+
+/**
+ * Scan a Claude Code plugin for commands and skills.
+ *
+ * @param pluginDir - Plugin root directory
+ * @param scope - "user" or "project"
+ * @returns Array of completion items
+ */
+export async function scanPlugin(
+  pluginDir: string,
+  scope: "user" | "project",
+): Promise<Item[]> {
+  try {
+    // Validate plugin
+    if (!(await isValidPlugin(pluginDir))) {
+      return [];
+    }
+
+    const pluginName = basename(pluginDir);
+    const items: Item[] = [];
+
+    // Scan commands/ directory
+    const commandsDir = join(pluginDir, "commands");
+    const commandItems = await scanPluginDirectory(
+      commandsDir,
+      pluginName,
+      "commands",
+      scope,
+    );
+    items.push(...commandItems);
+
+    // Scan skills/ directory
+    const skillsDir = join(pluginDir, "skills");
+    const skillItems = await scanPluginDirectory(
+      skillsDir,
+      pluginName,
+      "skills",
+      scope,
+    );
+    items.push(...skillItems);
+
+    return items;
+  } catch {
+    return []; // Silent failure for fault isolation
+  }
+}
 
 /**
  * Scan a directory for slash commands or skills.
@@ -32,27 +192,37 @@ export async function scanDirectory(
   try {
     if (dirName === "skills") {
       // Skills: scan */SKILL.md pattern (Agent Skills standard)
+      const entries: string[] = [];
       for await (const entry of expandGlob(join(dir, "*/SKILL.md"))) {
         const skillName = basename(dirname(entry.path));
         // Exclude hidden directories
         if (skillName.startsWith(".")) continue;
+        entries.push(skillName);
+      }
+      // Lexical sort for deterministic results
+      entries.sort((a, b) => a.localeCompare(b));
+      for (const name of entries) {
         items.push({
-          word: "/" + skillName,
+          word: "/" + name,
           menu: `[skills:${scope}]`,
         });
       }
     } else {
       // Other directories: scan *.md files
+      const entries: string[] = [];
       for await (const entry of Deno.readDir(dir)) {
         if (!entry.isFile) continue;
         // Exclude hidden files
         if (entry.name.startsWith(".")) continue;
         // Check .md extension
         if (!entry.name.endsWith(".md")) continue;
-
-        const commandName = basename(entry.name, ".md");
+        entries.push(basename(entry.name, ".md"));
+      }
+      // Lexical sort for deterministic results
+      entries.sort((a, b) => a.localeCompare(b));
+      for (const name of entries) {
         items.push({
-          word: "/" + commandName,
+          word: "/" + name,
           menu: `[${dirName}:${scope}]`,
         });
       }
@@ -112,6 +282,33 @@ export class Source extends BaseSource<Params> {
       items.push(...dirItems);
     }
 
+    // Scan plugins if enabled (plugins: "auto" or "on")
+    if (params.plugins !== "off") {
+      // Scan userPluginPaths (absolute paths with ~ expansion)
+      for (const pluginPath of params.userPluginPaths) {
+        // Skip empty or whitespace-only paths
+        if (!pluginPath || !pluginPath.trim()) continue;
+        const expandedPath = pluginPath.replace(/^~/, homeDir);
+        const pluginItems = await scanPlugin(expandedPath, "user");
+        items.push(...pluginItems);
+      }
+
+      // Scan projectPluginPaths (relative paths only, with boundary check)
+      for (const pluginPath of params.projectPluginPaths) {
+        // Skip empty or whitespace-only paths
+        if (!pluginPath || !pluginPath.trim()) continue;
+        // Reject absolute paths in projectPluginPaths
+        if (isAbsolute(pluginPath)) continue;
+        // Early rejection of path traversal attempts (defense in depth)
+        if (pluginPath.includes("..")) continue;
+        const resolvedPath = resolve(cwd, pluginPath);
+        // Security: verify path is within project boundary
+        if (!(await isWithinBoundary(resolvedPath, cwd))) continue;
+        const pluginItems = await scanPlugin(resolvedPath, "project");
+        items.push(...pluginItems);
+      }
+    }
+
     return items;
   }
 
@@ -119,6 +316,9 @@ export class Source extends BaseSource<Params> {
     return {
       userDirs: ["~/.claude/commands/", "~/.claude/skills/"],
       projectDirs: [".claude/commands/", ".claude/skills/"],
+      plugins: "off",
+      userPluginPaths: [],
+      projectPluginPaths: [],
     };
   }
 }

--- a/denops/@ddc-sources/slash_commands_test.ts
+++ b/denops/@ddc-sources/slash_commands_test.ts
@@ -1,6 +1,11 @@
 import { assertEquals } from "jsr:@std/assert";
 import { join } from "jsr:@std/path";
-import { scanDirectory } from "./slash_commands.ts";
+import {
+  isWithinBoundary,
+  scanDirectory,
+  scanPlugin,
+  scanPluginDirectory,
+} from "./slash_commands.ts";
 
 // Helper to create temp directory structure
 async function withTempDir(
@@ -135,5 +140,403 @@ Deno.test("scanDirectory - project scope has correct menu label", async () => {
     const items = await scanDirectory(commandsDir, "project");
 
     assertEquals(items[0].menu, "[commands:project]");
+  });
+});
+
+// ============================================================================
+// Plugin Tests
+// ============================================================================
+
+// Helper to create a valid plugin structure
+async function createPlugin(
+  pluginDir: string,
+  options?: { commands?: string[]; skills?: string[] },
+): Promise<void> {
+  // Create .claude-plugin/plugin.json (required for valid plugin)
+  const manifestDir = join(pluginDir, ".claude-plugin");
+  await Deno.mkdir(manifestDir, { recursive: true });
+  await Deno.writeTextFile(
+    join(manifestDir, "plugin.json"),
+    JSON.stringify({ name: "test-plugin", version: "1.0.0" }),
+  );
+
+  // Create commands
+  if (options?.commands && options.commands.length > 0) {
+    const commandsDir = join(pluginDir, "commands");
+    await Deno.mkdir(commandsDir, { recursive: true });
+    for (const cmd of options.commands) {
+      await Deno.writeTextFile(join(commandsDir, `${cmd}.md`), `# ${cmd}`);
+    }
+  }
+
+  // Create skills
+  if (options?.skills && options.skills.length > 0) {
+    const skillsDir = join(pluginDir, "skills");
+    await Deno.mkdir(skillsDir, { recursive: true });
+    for (const skill of options.skills) {
+      const skillDir = join(skillsDir, skill);
+      await Deno.mkdir(skillDir, { recursive: true });
+      await Deno.writeTextFile(join(skillDir, "SKILL.md"), `# ${skill}`);
+    }
+  }
+}
+
+Deno.test("scanPlugin - valid plugin with commands", async () => {
+  await withTempDir(async (tempDir) => {
+    const pluginDir = join(tempDir, "my-plugin");
+    await createPlugin(pluginDir, { commands: ["review", "deploy"] });
+
+    const items = await scanPlugin(pluginDir, "user");
+
+    assertEquals(items.length, 2);
+    assertEquals(items.some((i) => i.word === "/my-plugin:review"), true);
+    assertEquals(items.some((i) => i.word === "/my-plugin:deploy"), true);
+    assertEquals(items[0].menu, "[plugin:user]");
+  });
+});
+
+Deno.test("scanPlugin - valid plugin with skills", async () => {
+  await withTempDir(async (tempDir) => {
+    const pluginDir = join(tempDir, "my-plugin");
+    await createPlugin(pluginDir, { skills: ["code-review", "testing"] });
+
+    const items = await scanPlugin(pluginDir, "user");
+
+    assertEquals(items.length, 2);
+    assertEquals(items.some((i) => i.word === "/my-plugin:code-review"), true);
+    assertEquals(items.some((i) => i.word === "/my-plugin:testing"), true);
+    assertEquals(items[0].menu, "[plugin:user]");
+  });
+});
+
+Deno.test("scanPlugin - valid plugin with both commands and skills", async () => {
+  await withTempDir(async (tempDir) => {
+    const pluginDir = join(tempDir, "my-plugin");
+    await createPlugin(pluginDir, {
+      commands: ["commit", "push"],
+      skills: ["git-helper"],
+    });
+
+    const items = await scanPlugin(pluginDir, "project");
+
+    assertEquals(items.length, 3);
+    // All items have same menu format [plugin:scope]
+    assertEquals(items.filter((i) => i.menu === "[plugin:project]").length, 3);
+    // Verify command format: /plugin-name:command-name
+    assertEquals(items.some((i) => i.word === "/my-plugin:commit"), true);
+    assertEquals(items.some((i) => i.word === "/my-plugin:push"), true);
+    assertEquals(items.some((i) => i.word === "/my-plugin:git-helper"), true);
+  });
+});
+
+Deno.test("scanPlugin - invalid plugin without manifest returns empty", async () => {
+  await withTempDir(async (tempDir) => {
+    const pluginDir = join(tempDir, "invalid-plugin");
+    await Deno.mkdir(pluginDir);
+    // Create commands but no .claude-plugin/plugin.json
+    const commandsDir = join(pluginDir, "commands");
+    await Deno.mkdir(commandsDir);
+    await Deno.writeTextFile(join(commandsDir, "cmd.md"), "# Command");
+
+    const items = await scanPlugin(pluginDir, "user");
+
+    assertEquals(items.length, 0);
+  });
+});
+
+Deno.test("scanPlugin - non-existent plugin returns empty", async () => {
+  const items = await scanPlugin("/non/existent/plugin", "user");
+  assertEquals(items.length, 0);
+});
+
+Deno.test("scanPlugin - empty plugin (valid manifest but no commands/skills)", async () => {
+  await withTempDir(async (tempDir) => {
+    const pluginDir = join(tempDir, "empty-plugin");
+    await createPlugin(pluginDir, {}); // No commands or skills
+
+    const items = await scanPlugin(pluginDir, "user");
+
+    assertEquals(items.length, 0);
+  });
+});
+
+Deno.test("scanPluginDirectory - commands with lexical sort", async () => {
+  await withTempDir(async (tempDir) => {
+    const commandsDir = join(tempDir, "commands");
+    await Deno.mkdir(commandsDir);
+    // Create in non-alphabetical order
+    await Deno.writeTextFile(join(commandsDir, "zebra.md"), "# Z");
+    await Deno.writeTextFile(join(commandsDir, "alpha.md"), "# A");
+    await Deno.writeTextFile(join(commandsDir, "middle.md"), "# M");
+
+    const items = await scanPluginDirectory(
+      commandsDir,
+      "test-plugin",
+      "commands",
+      "user",
+    );
+
+    assertEquals(items.length, 3);
+    // Should be sorted alphabetically with plugin name prefix
+    assertEquals(items[0].word, "/test-plugin:alpha");
+    assertEquals(items[1].word, "/test-plugin:middle");
+    assertEquals(items[2].word, "/test-plugin:zebra");
+  });
+});
+
+Deno.test("scanPluginDirectory - skills with lexical sort", async () => {
+  await withTempDir(async (tempDir) => {
+    const skillsDir = join(tempDir, "skills");
+    // Create in non-alphabetical order
+    for (const name of ["zeta", "alpha", "beta"]) {
+      const dir = join(skillsDir, name);
+      await Deno.mkdir(dir, { recursive: true });
+      await Deno.writeTextFile(join(dir, "SKILL.md"), `# ${name}`);
+    }
+
+    const items = await scanPluginDirectory(
+      skillsDir,
+      "test-plugin",
+      "skills",
+      "project",
+    );
+
+    assertEquals(items.length, 3);
+    // Should be sorted alphabetically with plugin name prefix
+    assertEquals(items[0].word, "/test-plugin:alpha");
+    assertEquals(items[1].word, "/test-plugin:beta");
+    assertEquals(items[2].word, "/test-plugin:zeta");
+    assertEquals(items[0].menu, "[plugin:project]");
+  });
+});
+
+Deno.test("scanPluginDirectory - excludes hidden files in commands", async () => {
+  await withTempDir(async (tempDir) => {
+    const commandsDir = join(tempDir, "commands");
+    await Deno.mkdir(commandsDir);
+    await Deno.writeTextFile(join(commandsDir, "visible.md"), "# Visible");
+    await Deno.writeTextFile(join(commandsDir, ".hidden.md"), "# Hidden");
+
+    const items = await scanPluginDirectory(
+      commandsDir,
+      "test-plugin",
+      "commands",
+      "user",
+    );
+
+    assertEquals(items.length, 1);
+    assertEquals(items[0].word, "/test-plugin:visible");
+  });
+});
+
+Deno.test("scanPluginDirectory - excludes hidden directories in skills", async () => {
+  await withTempDir(async (tempDir) => {
+    const skillsDir = join(tempDir, "skills");
+
+    // Visible skill
+    const visibleDir = join(skillsDir, "visible");
+    await Deno.mkdir(visibleDir, { recursive: true });
+    await Deno.writeTextFile(join(visibleDir, "SKILL.md"), "# Visible");
+
+    // Hidden skill
+    const hiddenDir = join(skillsDir, ".hidden");
+    await Deno.mkdir(hiddenDir, { recursive: true });
+    await Deno.writeTextFile(join(hiddenDir, "SKILL.md"), "# Hidden");
+
+    const items = await scanPluginDirectory(
+      skillsDir,
+      "test-plugin",
+      "skills",
+      "user",
+    );
+
+    assertEquals(items.length, 1);
+    assertEquals(items[0].word, "/test-plugin:visible");
+  });
+});
+
+Deno.test("scanPluginDirectory - excludes non-.md files in commands", async () => {
+  await withTempDir(async (tempDir) => {
+    const commandsDir = join(tempDir, "commands");
+    await Deno.mkdir(commandsDir);
+    await Deno.writeTextFile(join(commandsDir, "valid.md"), "# Valid");
+    await Deno.writeTextFile(join(commandsDir, "invalid.txt"), "Invalid");
+    await Deno.writeTextFile(join(commandsDir, "also-invalid.json"), "{}");
+
+    const items = await scanPluginDirectory(
+      commandsDir,
+      "test-plugin",
+      "commands",
+      "user",
+    );
+
+    assertEquals(items.length, 1);
+    assertEquals(items[0].word, "/test-plugin:valid");
+  });
+});
+
+Deno.test("scanPluginDirectory - non-existent directory returns empty", async () => {
+  const items = await scanPluginDirectory(
+    "/non/existent/dir",
+    "test-plugin",
+    "commands",
+    "user",
+  );
+  assertEquals(items.length, 0);
+});
+
+Deno.test("scanPlugin - duplicate commands across plugins produce separate items", async () => {
+  await withTempDir(async (tempDir) => {
+    // Create two plugins with same command name
+    const plugin1 = join(tempDir, "plugin1");
+    const plugin2 = join(tempDir, "plugin2");
+    await createPlugin(plugin1, { commands: ["shared-cmd"] });
+    await createPlugin(plugin2, { commands: ["shared-cmd"] });
+
+    const items1 = await scanPlugin(plugin1, "user");
+    const items2 = await scanPlugin(plugin2, "user");
+
+    // Both should return the command with their plugin name prefix
+    assertEquals(items1.length, 1);
+    assertEquals(items2.length, 1);
+    assertEquals(items1[0].word, "/plugin1:shared-cmd");
+    assertEquals(items2[0].word, "/plugin2:shared-cmd");
+  });
+});
+
+Deno.test("scanPlugin - mixed valid/invalid continues scanning", async () => {
+  await withTempDir(async (tempDir) => {
+    const pluginDir = join(tempDir, "mixed-plugin");
+    await createPlugin(pluginDir, { commands: ["valid-cmd"] });
+
+    // Create an invalid skill directory (no SKILL.md)
+    const invalidSkillDir = join(pluginDir, "skills", "invalid-skill");
+    await Deno.mkdir(invalidSkillDir, { recursive: true });
+    await Deno.writeTextFile(join(invalidSkillDir, "README.md"), "# Not a skill");
+
+    const items = await scanPlugin(pluginDir, "user");
+
+    // Should still return the valid command with plugin name prefix
+    assertEquals(items.length, 1);
+    assertEquals(items[0].word, "/mixed-plugin:valid-cmd");
+  });
+});
+
+// ============================================================================
+// Security Tests
+// ============================================================================
+
+Deno.test("isWithinBoundary - path within boundary returns true", async () => {
+  await withTempDir(async (tempDir) => {
+    const subDir = join(tempDir, "subdir");
+    await Deno.mkdir(subDir);
+
+    const result = await isWithinBoundary(subDir, tempDir);
+
+    assertEquals(result, true);
+  });
+});
+
+Deno.test("isWithinBoundary - exact boundary path returns true", async () => {
+  await withTempDir(async (tempDir) => {
+    const result = await isWithinBoundary(tempDir, tempDir);
+
+    assertEquals(result, true);
+  });
+});
+
+Deno.test("isWithinBoundary - path outside boundary returns false", async () => {
+  await withTempDir(async (tempDir) => {
+    const outsidePath = "/tmp";
+
+    const result = await isWithinBoundary(outsidePath, tempDir);
+
+    assertEquals(result, false);
+  });
+});
+
+Deno.test("isWithinBoundary - non-existent path returns false", async () => {
+  await withTempDir(async (tempDir) => {
+    const nonExistent = join(tempDir, "does-not-exist");
+
+    const result = await isWithinBoundary(nonExistent, tempDir);
+
+    assertEquals(result, false);
+  });
+});
+
+Deno.test("isWithinBoundary - symlink within boundary returns true", async () => {
+  await withTempDir(async (tempDir) => {
+    const targetDir = join(tempDir, "target");
+    await Deno.mkdir(targetDir);
+    const symlinkPath = join(tempDir, "link");
+    await Deno.symlink(targetDir, symlinkPath);
+
+    const result = await isWithinBoundary(symlinkPath, tempDir);
+
+    assertEquals(result, true);
+  });
+});
+
+Deno.test("isWithinBoundary - symlink outside boundary returns false", async () => {
+  await withTempDir(async (tempDir) => {
+    // Create symlink pointing outside the temp directory
+    const symlinkPath = join(tempDir, "escape-link");
+    await Deno.symlink("/tmp", symlinkPath);
+
+    const result = await isWithinBoundary(symlinkPath, tempDir);
+
+    assertEquals(result, false);
+  });
+});
+
+Deno.test("isWithinBoundary - similar prefix path returns false", async () => {
+  // Test that /project-other is not considered within /project
+  await withTempDir(async (tempDir) => {
+    const projectDir = join(tempDir, "project");
+    const projectOtherDir = join(tempDir, "project-other");
+    await Deno.mkdir(projectDir);
+    await Deno.mkdir(projectOtherDir);
+
+    const result = await isWithinBoundary(projectOtherDir, projectDir);
+
+    assertEquals(result, false);
+  });
+});
+
+Deno.test("scanDirectory - results are lexically sorted", async () => {
+  await withTempDir(async (tempDir) => {
+    const commandsDir = join(tempDir, "commands");
+    await Deno.mkdir(commandsDir);
+    // Create in non-alphabetical order
+    await Deno.writeTextFile(join(commandsDir, "zebra.md"), "# Z");
+    await Deno.writeTextFile(join(commandsDir, "alpha.md"), "# A");
+    await Deno.writeTextFile(join(commandsDir, "middle.md"), "# M");
+
+    const items = await scanDirectory(commandsDir, "user");
+
+    assertEquals(items.length, 3);
+    assertEquals(items[0].word, "/alpha");
+    assertEquals(items[1].word, "/middle");
+    assertEquals(items[2].word, "/zebra");
+  });
+});
+
+Deno.test("scanDirectory - skills results are lexically sorted", async () => {
+  await withTempDir(async (tempDir) => {
+    const skillsDir = join(tempDir, "skills");
+    // Create in non-alphabetical order
+    for (const name of ["zeta", "alpha", "beta"]) {
+      const dir = join(skillsDir, name);
+      await Deno.mkdir(dir, { recursive: true });
+      await Deno.writeTextFile(join(dir, "SKILL.md"), `# ${name}`);
+    }
+
+    const items = await scanDirectory(skillsDir, "user");
+
+    assertEquals(items.length, 3);
+    assertEquals(items[0].word, "/alpha");
+    assertEquals(items[1].word, "/beta");
+    assertEquals(items[2].word, "/zeta");
   });
 });


### PR DESCRIPTION
## Summary

- Add Claude Code plugin support with manual path configuration
- New parameters: `plugins`, `userPluginPaths`, `projectPluginPaths`
- Format: `/plugin-name:command-name` with `[plugin:scope]` menu label
- Security features: path traversal prevention, boundary checking

## Test plan

- [x] Run `deno test -A` - 33 tests pass
- [ ] Test with actual Claude Code plugins
- [ ] Verify completion works in Vim/Neovim

Closes #7